### PR TITLE
Prepare for DOID using new OMIMPS prefix

### DIFF
--- a/src/org/jax/mgi/fewi/util/link/IDLinker.java
+++ b/src/org/jax/mgi/fewi/util/link/IDLinker.java
@@ -472,6 +472,12 @@ public class IDLinker {
 		if(dbName.equals("OMIM") || dbName.equals("OMIM:PS")) {
 			id = id.replaceAll("OMIM:", "");
 		}
+		/* Prepare for DOID to apply proper prefixes for OMIM Phenotype series terms
+		 * See: https://github.com/DiseaseOntology/HumanDiseaseOntology/pull/968
+		 */
+		if(dbName.equals("OMIMPS")) {
+			id = id.replaceAll("OMIMPS:", "");
+		}
 		if(dbName.equals("NCI")) {
 			id = id.replaceAll("NCI:", "");
 		}


### PR DESCRIPTION
I've sent DOID a pull request to use a more appropriate prefix for OMIM Phenotype series identifiers rather than grouping them with other OMIM terms. This change will make MGI's code both forward and backwards compatible.

See original discussion at DiseaseOntology/HumanDiseaseOntology#968 and the related issue (linked in its description)

Related: 
- https://github.com/mgijax/vocload/pull/1