### PR TITLE
Prepare for DOID using new OMIMPS prefix

### DIFF
--- a/www/WEB-INF/jsp/disease_browser.jsp
+++ b/www/WEB-INF/jsp/disease_browser.jsp
@@ -174,7 +174,8 @@
 		                  id.logicalDB == 'ORDO' ||
 		                  id.logicalDB == 'KEGG' ||
 		                  id.logicalDB == 'NCI' ||
-		                  id.logicalDB == 'OMIM:PS' ||
+		                  id.logicalDB == 'OMIMPS' ||
+				  id.logicalDB == 'OMIM:PS' ||
 		                  id.logicalDB == 'MESH' ||
 		                  id.logicalDB == 'EFO'}">
 		    <% id = (VocabTermID) pageContext.getAttribute("id"); %>


### PR DESCRIPTION
I've sent DOID a pull request to use a more appropriate prefix for OMIM Phenotype series identifiers rather than grouping them with other OMIM terms. This change will make MGI's code both forward and backwards compatible.

See original discussion at DiseaseOntology/HumanDiseaseOntology#968 and the related issue (linked in its description)

Related: 
- https://github.com/mgijax/vocload/pull/1
- https://github.com/mgijax/fewi/pull/1